### PR TITLE
Installer tags

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -391,7 +391,13 @@ if [ -z $AGENTKEY ]; then
             echo "Found $TAGNAME, using tag ID $TAGID"
 
         else
-            HEX="#`echo -n $TAGNAME | md5 | cut -c1-6`"
+
+            MD5=`which md5`
+            if [ -z $MD5 ]; then
+                MD5=`which md5sum`
+            fi
+
+            HEX="#`echo -n $TAGNAME | $MD5 | cut -c1-6`"
             echo "Creating tag $TAGNAME with random hex code $HEX"
             TAGS=`curl --silent -X POST https://api.serverdensity.io/inventory/tags?token=${API_KEY} --data "name=$TAGNAME&color=$HEX"`
             TAGID=`echo $TAGS | grep -i $TAGNAME | sed 's/.*"_id":"\([a-z0-9]*\)".*/\1/g'`

--- a/install.sh
+++ b/install.sh
@@ -385,7 +385,7 @@ if [ -z $AGENTKEY ]; then
         TAGS=`curl --silent -X GET https://api.serverdensity.io/inventory/tags?token=${API_KEY}`
 
         # very messy way to get the tag ID without using any json tools
-        TAGID=`echo $TAGS | sed -e $'s/},{/\\\n/g'| grep -i $TAGNAME | sed 's/.*"_id":"\([a-z0-9]*\)".*/\1/g'` 
+        TAGID=`echo $TAGS | sed -e $'s/},{/\\\n/g'| grep -i "\"$TAGNAME"\" | sed 's/.*"_id":"\([a-z0-9]*\)".*/\1/g'` 
 
         if [ ! -z $TAGID ]; then
             echo "Found $TAGNAME, using tag ID $TAGID"

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ function print_help() {
     echo "      -k: Agent key. Not required if API token provided. "
     echo "      -t: API token. Not required if agent key provided. "   
     echo "      -g: Group. Optional. Group to add the new device into."   
-    echo "      -T: Tag. Optional. Tag this device."   
+    echo "      -T: Tag. Optional. Tag this device - multiple tags not supported."   
     exit 0
 }
  

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ function do_install() {
         echo "Adding repository"
         sudo sh -c "echo \"deb http://www.serverdensity.com/downloads/linux/deb all main\" > /etc/apt/sources.list.d/sd-agent.list"
  
-        $CURL -s https://www.serverdensity.com/downloads/boxedice-public.key | sudo apt-key add -
+        $CURL -Ls https://www.serverdensity.com/downloads/boxedice-public.key | sudo apt-key add -
         if [ $? -gt 0 ]; then
             echo "Error downloading key"
             exit 1

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ function print_help() {
     echo "      -k: Agent key. Not required if API token provided. "
     echo "      -t: API token. Not required if agent key provided. "   
     echo "      -g: Group. Optional. Group to add the new device into."   
-    echo "      -T: Tag name."   
+    echo "      -T: Tag. Optional. Tag this device."   
     exit 0
 }
  
@@ -396,10 +396,11 @@ if [ -z $AGENTKEY ]; then
             if [ -z $MD5 ]; then
                 MD5=`which md5sum`
             fi
-
             HEX="#`echo -n $TAGNAME | $MD5 | cut -c1-6`"
+
             echo "Creating tag $TAGNAME with random hex code $HEX"
             TAGS=`curl --silent -X POST https://api.serverdensity.io/inventory/tags?token=${API_KEY} --data "name=$TAGNAME&color=$HEX"`
+
             TAGID=`echo $TAGS | grep -i $TAGNAME | sed 's/.*"_id":"\([a-z0-9]*\)".*/\1/g'`
             echo "Tag cretated, using tag ID $TAGID"
 
@@ -413,7 +414,7 @@ if [ -z $AGENTKEY ]; then
             RESULT=`curl -v https://api.serverdensity.io/inventory/devices/?token=${API_KEY} --data "group=${GROUPNAME}&name=${HOSTNAME}&tags=[\"$TAGID\"]"`
         fi 
 
-    elif [ "${TAGNAME}" = "" ]; then
+    else
 
         if [ "${GROUPNAME}" = "" ]; then
             RESULT=`curl -v https://api.serverdensity.io/inventory/devices/?token=${API_KEY} --data "name=${HOSTNAME}"`


### PR DESCRIPTION
Adds tagging ability into the installer
Usage: sd-install.sh -a account -t token -T newtag

- Retrieves all existing tags using the API
- Using sed/grep to see if the tag exists
- If it does, stores the ID in TAGID
- If it doesn't, creates the tag and stores the ID in TAGID using a random hex code (echo tagname | md5 | cut -c1-6)
