### PR TITLE
We are just interested on remove the 'google-' prefix from the diskName

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -538,7 +538,7 @@ class checks:
 
                 diskNameFull = device.split('/')[-1]
                 disks.append({
-                    'volumeName': diskNameFull.split('-')[1],
+                    'volumeName': diskNameFull.split('-', 1)[1],
                     'device': deviceName
                 })
 


### PR DESCRIPTION
This should fix the bug when we extract the wrong volume name from GCE machines if they have a '-' char in its name.

Without this patch, if we find:

/dev/disk/by-id/google-cpm-test

the volumeName would be extracted as 'cpm' instead of 'cpm-test'