### PR TITLE
First line of apache status page isn't always a key value pair

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -145,13 +145,14 @@ class checks:
 
             # Loop through and extract the numerical values
             for line in lines:
-                values = line.split(': ')
+                if ': ' in line:
+                    values = line.split(': ')
 
-                try:
-                    apacheStatus[str(values[0])] = values[1]
+                    try:
+                        apacheStatus[str(values[0])] = values[1]
 
-                except IndexError:
-                    break
+                    except IndexError:
+                        break
 
             self.mainLogger.debug('getApacheStatus: parsed')
 


### PR DESCRIPTION
On my server the first couple lines of my status page look something like this


status
ServerVersion: Apache/2.4.16 (Unix)
ServerMPM: event

Since the first line isn't a key value pair the break control flow exited at the start. Instead its better to check if the line contains ': ' and then proceed.