### PR TITLE
- Update shebang

### DIFF
--- a/utils/pip-allow-failures.sh
+++ b/utils/pip-allow-failures.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PIP_COMMAND=${PIP_COMMAND:-pip}
 PIP_OPTIONS=${PIP_OPTIONS:-}


### PR DESCRIPTION
Updated shebang to make pip-allow-failures.sh script portable.

@carlosperello can you review please? 