### PR TITLE
Relax gohai exception

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -649,7 +649,7 @@ class Collector(object):
                 if e.errno == 2:  # file not found, expected when install from source
                     log.info("gohai file not found")
                 else:
-                    raise e
+                    log.info("gohai command failed with error %s" % str(e))
             except Exception as e:
                 log.warning("gohai command failed with error %s" % str(e))
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -649,7 +649,7 @@ class Collector(object):
                 if e.errno == 2:  # file not found, expected when install from source
                     log.info("gohai file not found")
                 else:
-                    log.info("gohai command failed with error %s" % str(e))
+                    log.warning("Unexpected OSError when running gohai %s", e)
             except Exception as e:
                 log.warning("gohai command failed with error %s" % str(e))
 


### PR DESCRIPTION
If the gohai command raises an exception then simply log it as
informational rather than throw an exception or log as an error.

This means we can close SD-2129.

@carlosperello can you review please?