### PR TITLE
SD-2316 Update darwin support

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,4 +1,4 @@
-#!/usr/share/python/sd-agent/bin/python
+#!/usr/bin/env python
 '''
     Server Density
     www.serverdensity.com

--- a/checks.d/sd.py
+++ b/checks.d/sd.py
@@ -22,6 +22,13 @@ class ServerDensityChecks(AgentCheck):
     """ Collects metrics about the machine's disks. """
 
     DF_COMMAND = ['df', '-k']
+    
+    # According to SUSv3 (which Mac OS X follows)
+    # the default is to show inode information
+    # So we need to suppress that output with -P
+    # See df(1) for details
+    if sys.platform == 'darwin':
+        DF_COMMAND = ['df', '-k', '-P']
 
     def check(self, instance):
         #self.log.debug('hello')

--- a/checks.d/sd.py
+++ b/checks.d/sd.py
@@ -22,7 +22,7 @@ class ServerDensityChecks(AgentCheck):
     """ Collects metrics about the machine's disks. """
 
     DF_COMMAND = ['df', '-k']
-    
+
     # According to SUSv3 (which Mac OS X follows)
     # the default is to show inode information
     # So we need to suppress that output with -P

--- a/checks.d/sd_cpu_stats.py
+++ b/checks.d/sd_cpu_stats.py
@@ -118,7 +118,10 @@ class ServerDensityCPUChecks(AgentCheck):
                         values = re.findall(itemRegexp, line)
 
                 if values and titles:
-                    cpu_stats['CPUs'] = dict(zip(titles, values))
+                    cpu_stats['ALL'] = dict(zip(titles, values))
+                    for headerIndex in range(0, len(titles)):
+                        key = titles[headerIndex].replace('%', '')
+                        self.gauge('serverdensity.cpu.{0}'.format(key), float(values[headerIndex]), device_name='ALL')
 
             except Exception:
                 import traceback

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -402,7 +402,7 @@ class Memory(Check):
 
             # Deal with top
             lines = top.split('\n')
-            physParts = re.findall(r'([0-9]\d+)', lines[self.topIndex])
+            physParts = re.findall(r'([0-9]\d+[MG])', lines[self.topIndex])
 
             # Deal with sysctl
             swapParts = re.findall(r'([0-9]+\.\d+)', sysctl)
@@ -413,6 +413,15 @@ class Memory(Check):
             if macV and (macV_minor_version >= 9):
                 physUsedPartIndex = 0
                 physFreePartIndex = 2
+
+            # large values become G, rather than M
+            finalParts = []
+            for part in physParts:
+                if 'G' in part:
+                    finalParts.append(str(int(part[:-1]) * 1024))
+                else:
+                    finalParts.append(part[:-1])
+            physParts = finalParts
 
             return {'physUsed': physParts[physUsedPartIndex], 'physFree': physParts[physFreePartIndex], 'swapUsed': swapParts[1], 'swapFree': swapParts[2]}
 


### PR DESCRIPTION
#### What's this PR do?
It adapts the agent's source to run properly on Mac OS X systems (aka Darwin) taking into account its idiosyncrasies.

#### Where should the reviewer start?
The commits are small and pretty much self-explanatory. They're also properly isolated from other's systems branches (except for the shebang change, which should work on any system)

#### How should this be manually tested?
Install the agent from source and run it, check that the metrics reported are correct, as opposed to before the changes

#### Any background context you want to provide?
Most of the differences lay in the system utilities, which accept different arguments or produce other output by default.

There's also a pending ticket referring to the way CPU stats are reported. No default system utility in OS X reports CPU activity per CPU. This needs to be fixed with a custom utility, or changing the UI (and mobile clients) requests metrics for darwin systems.

#### What are the relevant tickets?
https://serverdensity.atlassian.net/browse/SD-2316

#### Screenshots 
Before and after:

![captura de pantalla 2016-05-20 a les 10 23 03](https://cloud.githubusercontent.com/assets/7311/15429158/7de1deba-1e97-11e6-9ba3-b7ece0f3f721.png)
![captura de pantalla 2016-05-20 a les 10 44 05](https://cloud.githubusercontent.com/assets/7311/15429162/83e61bbe-1e97-11e6-87c2-ab4cc3cd1451.png)
![captura de pantalla 2016-05-19 a les 14 12 49](https://cloud.githubusercontent.com/assets/7311/15429169/8b32e028-1e97-11e6-98f8-15923359b200.png)
![captura de pantalla 2016-05-20 a les 10 19 14](https://cloud.githubusercontent.com/assets/7311/15429172/8eab551e-1e97-11e6-87eb-cad5f3aaf3c3.png)


#### Who should review or be notified about this?
@serverdensity/backend-engineering 