### PR TITLE
Release 2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - SKIP_CLEANUP=true
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - AGENT_VERSION=2.1.3
+    - AGENT_VERSION=2.1.4
   matrix:
     - TRAVIS_FLAVOR=default
     - TRAVIS_FLAVOR=core_integration

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ from utils.subprocess_output import (
 )
 
 # CONSTANTS
-AGENT_VERSION = "2.1.3"
+AGENT_VERSION = "2.1.4"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'
 MAC_CONFIG_PATH = '/usr/local/etc/sd-agent/'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent (2.1.4-1) precise; urgency=medium
+
+  * Added support for HDFS plugin.
+
+ -- Server Density <hello@serverdensity.com>  Tue, 8 Nov 2016 14:21:58 +0100
+
 sd-agent (2.1.3-1) precise; urgency=medium
 
   * Added support for elastic search plugin.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 sd-agent (2.1.4-1) precise; urgency=medium
 
   * Added support for HDFS plugin.
+  * Fixed pycurl SSL support.
 
  -- Server Density <hello@serverdensity.com>  Tue, 8 Nov 2016 14:21:58 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -128,6 +128,19 @@ Description: The Server Density monitoring agent - HAProxy plugin
  .
  See https://www.serverdensity.com/ for more information.
 
+Package: sd-agent-hdfs
+Architecture: all
+Pre-Depends: dpkg (>= 1.15.12), python2.7 | python2.6, ${misc:Pre-Depends}
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.4)
+Description: The Server Density monitoring agent - HDFS plugin
+ The Server Density monitoring agent is a lightweight process that monitors
+ system processes and services, and sends information back to your Server
+ Density account.
+ .
+ This package installs the HDFS plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
 Package: sd-agent-kafka-consumer
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.12), python2.7 | python2.6, ${misc:Pre-Depends}

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Homepage: http://www.serverdensity.com/
 Package: sd-agent
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.12), python2.7 | python2.6, adduser, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, sysstat
+Depends: ${python:Depends}, ${misc:Depends}, sysstat, libcurl3-gnutls
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/sd-agent-hdfs.install
+++ b/debian/sd-agent-hdfs.install
@@ -1,0 +1,4 @@
+checks.d/hdfs_datanode.py usr/share/python/sd-agent/checks.d
+checks.d/hdfs_namenode.py usr/share/python/sd-agent/checks.d
+conf.d/hdfs_datanode.yaml.example etc/sd-agent/conf.d
+conf.d/hdfs_namenode.yaml.example etc/sd-agent/conf.d

--- a/packaging/darwin/build_installer.sh
+++ b/packaging/darwin/build_installer.sh
@@ -139,6 +139,12 @@ cp conf.d/docker.yaml.example ${INSTALL_DIR}/etc/sd-agent/conf.d
 cp checks.d/elastic.py ${INSTALL_DIR}/sd-agent/checks.d
 cp conf.d/elastic.yaml.example ${INSTALL_DIR}/etc/sd-agent/conf.d
 
+# HDFS
+cp checks.d/hdfs_datanode.py ${INSTALL_DIR}/sd-agent/checks.d
+cp checks.d/hdfs_namenode.py ${INSTALL_DIR}/sd-agent/checks.d
+cp conf.d/hdfs_datanode.yaml.example ${INSTALL_DIR}/etc/sd-agent/conf.d
+cp conf.d/hdfs_namenode.yaml.example ${INSTALL_DIR}/etc/sd-agent/conf.d
+
 # HAProxy
 cp checks.d/haproxy.py ${INSTALL_DIR}/sd-agent/checks.d
 cp conf.d/haproxy.yaml.example ${INSTALL_DIR}/etc/sd-agent/conf.d

--- a/packaging/darwin/darwin_version.sh
+++ b/packaging/darwin/darwin_version.sh
@@ -1,2 +1,2 @@
 # Source this file to import version info
-AGENT_VERSION=2.1.3
+AGENT_VERSION=2.1.4

--- a/packaging/darwin/distribution.xml
+++ b/packaging/darwin/distribution.xml
@@ -18,5 +18,5 @@
     <choice id="com.serverdensity.agent-service" visible="false">
         <pkg-ref id="com.serverdensity.agent-service"/>
     </choice>
-    <pkg-ref id="com.serverdensity.agent-service" version="2.1.3" onConclusion="none">Server%20Density%20Agent%20Service.pkg</pkg-ref>
+    <pkg-ref id="com.serverdensity.agent-service" version="2.1.4" onConclusion="none">Server%20Density%20Agent%20Service.pkg</pkg-ref>
 </installer-gui-script>

--- a/packaging/el/SPECS/sd-agent-el6.spec
+++ b/packaging/el/SPECS/sd-agent-el6.spec
@@ -36,7 +36,7 @@ python virtualenv-13.1.2/virtualenv.py %{__venv}
 
 %setup -qn sd-agent
 %{__venv}/bin/python %{__venv}/bin/pip install -r requirements.txt
-%{__venv}/bin/python %{__venv}/bin/pip install -r requirements-opt.txt
+PYCURL_SSL_LIBRARY=nss %{__venv}/bin/python %{__venv}/bin/pip install -r requirements-opt.txt
 
 %build
 %{__venv}/bin/python setup.py build

--- a/packaging/el/SPECS/sd-agent-el7.spec
+++ b/packaging/el/SPECS/sd-agent-el7.spec
@@ -36,7 +36,7 @@ python virtualenv-13.1.2/virtualenv.py %{__venv}
 
 %setup -qn sd-agent
 %{__venv}/bin/python %{__venv}/bin/pip install -r requirements.txt
-%{__venv}/bin/python %{__venv}/bin/pip install -r requirements-opt.txt
+PYCURL_SSL_LIBRARY=nss %{__venv}/bin/python %{__venv}/bin/pip install -r requirements-opt.txt
 
 %build
 %{__venv}/bin/python setup.py build

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,6 +1,7 @@
 %changelog
 * Tue Nov 08 2016 Server Density <hello@serverdensity.com> 2.1.4-1
 - Added support for HDFS plugin.
+- Fixed docker_daemon plugin installation.
 * Thu Sep 29 2016 Server Density <hello@serverdensity.com> 2.1.3-1
 - Added support for elastic search plugin.
 - Fixed haproxy packaging.

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -2,6 +2,7 @@
 * Tue Nov 08 2016 Server Density <hello@serverdensity.com> 2.1.4-1
 - Added support for HDFS plugin.
 - Fixed docker_daemon plugin installation.
+- Fixed pycurl SSL support.
 * Thu Sep 29 2016 Server Density <hello@serverdensity.com> 2.1.3-1
 - Added support for elastic search plugin.
 - Fixed haproxy packaging.

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+* Tue Nov 08 2016 Server Density <hello@serverdensity.com> 2.1.4-1
+- Added support for HDFS plugin.
 * Thu Sep 29 2016 Server Density <hello@serverdensity.com> 2.1.3-1
 - Added support for elastic search plugin.
 - Fixed haproxy packaging.

--- a/packaging/el/inc/install
+++ b/packaging/el/inc/install
@@ -37,7 +37,7 @@ ln -sf lib lib64
 popd
 
 # Plugins
-for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
+for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
     cp -a checks.d/${plugin}.py %{buildroot}/usr/share/python/sd-agent/checks.d
     cp -a conf.d/${plugin}.yaml.example %{buildroot}/etc/sd-agent/conf.d
 done

--- a/packaging/el/inc/install
+++ b/packaging/el/inc/install
@@ -37,7 +37,7 @@ ln -sf lib lib64
 popd
 
 # Plugins
-for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
+for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker docker_daemon elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
     cp -a checks.d/${plugin}.py %{buildroot}/usr/share/python/sd-agent/checks.d
     cp -a conf.d/${plugin}.yaml.example %{buildroot}/etc/sd-agent/conf.d
 done

--- a/packaging/el/inc/install.el5
+++ b/packaging/el/inc/install.el5
@@ -37,7 +37,7 @@ ln -sf lib lib64
 popd
 
 # Plugins
-for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
+for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
     cp -a checks.d/${plugin}.py %{buildroot}/usr/share/python/sd-agent/checks.d
     cp -a conf.d/${plugin}.yaml.example %{buildroot}/etc/sd-agent/conf.d
 done

--- a/packaging/el/inc/install.el5
+++ b/packaging/el/inc/install.el5
@@ -37,7 +37,7 @@ ln -sf lib lib64
 popd
 
 # Plugins
-for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
+for plugin in apache mongo mysql nginx rabbitmq btrfs consul couch directory docker docker_daemon elastic haproxy hdfs_datanode hdfs_namenode kafka_consumer mcache php_fpm postfix postgres redisdb riak riakcs supervisord varnish zk; do
     cp -a checks.d/${plugin}.py %{buildroot}/usr/share/python/sd-agent/checks.d
     cp -a conf.d/${plugin}.yaml.example %{buildroot}/etc/sd-agent/conf.d
 done

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -181,6 +181,23 @@ This package installs the HAProxy plugin.
 /usr/share/python/sd-agent/checks.d/haproxy.py
 %config /etc/sd-agent/conf.d/haproxy.yaml.example
 
+%package hdfs
+Summary: Server Density Monitoring Agent. HDFS plugin
+Group: System/Monitoring
+Requires: %{name} >= 2.1.4
+BuildArch: noarch
+
+%description hdfs
+%{longdescription}
+This package installs the HDFS plugin.
+
+%files hdfs
+%defattr(-,root,root,-)
+/usr/share/python/sd-agent/checks.d/hdfs_datanode.py
+/usr/share/python/sd-agent/checks.d/hdfs_namenode.py
+%config /etc/sd-agent/conf.d/hdfs_datanode.yaml.example
+%config /etc/sd-agent/conf.d/hdfs_namenode.yaml.example
+
 %package memcache
 Summary: Server Density Monitoring Agent. Memcached plugin
 Group: System/Monitoring

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -149,7 +149,9 @@ This package installs the Docker plugin.
 %files docker
 %defattr(-,root,root,-)
 /usr/share/python/sd-agent/checks.d/docker.py
+/usr/share/python/sd-agent/checks.d/docker_daemon.py
 %config /etc/sd-agent/conf.d/docker.yaml.example
+%config /etc/sd-agent/conf.d/docker_daemon.yaml.example
 
 %package elastic
 Summary: Server Density Monitoring Agent. Elastic Search plugin

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.1.3
+Version: 2.1.4

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,11 +1,3 @@
-######################## WARNING ##########################
-# This file currently determines the python deps installed
-# for the dev env, the source install and the Win build.
-# It is NOT used for the DEB/RPM packages and the OS X
-# build. For these please update:
-# https://github.com/DataDog/omnibus-software
-###########################################################
-
 # core/optional
 # tornado can work without pycurl and use the simple http client
 # but some features won't work, like the abylity to use a proxy

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -29,7 +29,7 @@ def configcheck():
         else:
             print "%s is valid" % basename
     if all_valid:
-        print "All yaml files passed. You can now run the Datadog agent."
+        print "All yaml files passed. You can now run the ServerDensity agent."
         return 0
     else:
         print("Fix the invalid yaml files above in order to start the Datadog agent. "


### PR DESCRIPTION
- Adds HDFS plugins official support.
- docker_daemon plugin fixed on .RPM packages
- pycurl fixes to use the agent as a proxy of other agents.