### PR TITLE
Stop source install

### DIFF
--- a/packaging/source/agent
+++ b/packaging/source/agent
@@ -31,9 +31,11 @@ supervisor_running() {
 
 execute_if_supervisor_running() {
     # Executes `supervisord -c $SUPERVISOR_CONF_FILE $*`
-    # if the supervisor is running.
+    # if the supervisor is running. Then kills the supervisord pid
     if supervisor_running; then
         supervisorctl -c $SUPERVISOR_CONF_FILE "$*"
+        pid=$(cat $PID_FILE)
+        kill $pid
         return $?
     else
         echo $SUPERVISOR_NOT_RUNNING

--- a/packaging/source/agent
+++ b/packaging/source/agent
@@ -6,7 +6,7 @@ PATH=$(pwd)/venv/bin:$PATH
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='agent/supervisor.conf'
-SOCK_FILE='run/sd-supervisor.sock'
+SOCK_FILE='run/agent-supervisor.sock'
 PID_FILE='run/supervisord.pid'
 COLLECTOR_PIDFILE='run/sd-agent.pid'
 action=$1


### PR DESCRIPTION
This PR allows agent source installs to be stopped by fixing the socket file location and by killing the leftover supervisord process id once all child processes have been stopped. 

Can be tested by installing a source install: 
`curl https://archive.serverdensity.com/agent-install-source.sh | sudo bash -s -- -a test -k testkey` (You don't need a valid account and key to test this)

Then start with `bin/agent start`
See that the agent starts, then attempt to stop with `bin/agent stop` 
and see that fails with `Supervisor is not running`. 
(Can also verify supervisord process is still running with `ps aux | grep sd-agent` or `ps aux | grep py`) 

Drop in the replacement from this branch and then attempt to `bin/agent stop` and see that you get
```
sd-agent:forwarder: stopped
sd-agent:sdstatsd: stopped
sd-agent:collector: stopped
```
and that there are no processes returned with `ps aux | grep sd-agent` 

@sixstone-qq please can you review? 
