### PR TITLE
Version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - AGENT_VERSION=2.2.0
+    - AGENT_VERSION=2.2.1
   matrix:
     - TRAVIS_FLAVOR=default
     - TRAVIS_FLAVOR=checks_mock

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "2.2.0"
+AGENT_VERSION = "2.2.1"
 JMX_VERSION = "0.15.0"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sd-agent (2.2.1-1trusty0) trusty; urgency=medium
+
+  * Fixed io stat collection for certain locales.
+  * Adds support for macOS CPU metrics.
+
+ -- Server Density <hello@serverdensity.com>  Mon, 16 Apr 2018 10:30:00 +0100
+
 sd-agent (2.2.0-3trusty0) trusty; urgency=medium
 
   * Fixed systemd startup scripts setup.

--- a/packaging/darwin/darwin_version.sh
+++ b/packaging/darwin/darwin_version.sh
@@ -1,2 +1,2 @@
 # Source this file to import version info
-AGENT_VERSION=2.1.6
+AGENT_VERSION=2.2.1

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Mon Apr 16 2018 Server Density <hello@serverdensity.com> 2.2.1-1
+- Fixed io stat collection for certain locales.
+- Adds support for macOS CPU metrics.
 * Tue Nov 21 2017 Server Density <hello@serverdensity.com> 2.2.0-1
 - Added support for JMX, and local StatsD collector.
 * Mon May 15 2017 Server Density <hello@serverdensity.com> 2.1.6-1

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.2.0
+Version: 2.2.1


### PR DESCRIPTION
This PR updates the files that contain the version number and changelogs for the next agent release.

To be merged after #153, #154 & #156

https://github.com/serverdensity/sd-agent-core-plugins/pull/12  and  https://github.com/serverdensity/sd-agent-core-plugins/pull/15 are also required too. 