### PR TITLE
Log orchestrator error in debug only

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -91,7 +91,7 @@ class DockerUtil:
                     self._is_rancher = True
                     break
         except Exception as e:
-            log.warning("Error while detecting orchestrator: %s" % e)
+            log.debug("Error while detecting orchestrator: %s" % e)
             pass
 
         try:


### PR DESCRIPTION
This PR prevents the orcherstator warning from being shown unless the agent is in debug mode. 

@carlosperello please can you review? 