### PR TITLE
Fix proxy tests

### DIFF
--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -169,6 +169,9 @@ class TestCore(unittest.TestCase):
             'no': '127.0.0.1,localhost,169.254.169.254'
         }
         environ_proxies = get_environ_proxies("https://www.google.com")
+        if os.environ.get('TRAVIS') and 'travis_apt' in environ_proxies:
+            # Travis CI adds a `travis_apt` proxy which breaks this test if it's not removed.
+            environ_proxies.pop("travis_apt", None)
         self.assertEquals(expected_proxies, environ_proxies,
                           (expected_proxies, environ_proxies))
 


### PR DESCRIPTION
This PR fixes the currently broken test on Travis. 

Travis appears to be adding a proxy named `travis_apt` which causes the test to fail as it is not in the expected proxies list. This appears to be a recent change (altho I can't find anything in the Travis docs about it).

Tests are passing on this branch on Travis . 

@carlosperello please can you review?  