### PR TITLE
Bump pyyaml to >=4.2b1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-consul==0.4.7
 # utils/service_discovery/config_stores.py
 python-etcd==0.4.5
 # the libyaml bindings are optional
-pyyaml==3.11
+pyyaml>=4.2b1
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.0


### PR DESCRIPTION
This PR increases the required pyyaml version to 4.2b1 to mitigate CVE-2017-18342.