### PR TITLE
Redirect systemd logs to null

### DIFF
--- a/debian/distros/bionic/sd-agent-forwarder.service
+++ b/debian/distros/bionic/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/bionic/sd-agent-jmx.service
+++ b/debian/distros/bionic/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/bionic/sd-agent-sdstatsd.service
+++ b/debian/distros/bionic/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/bionic/sd-agent.service
+++ b/debian/distros/bionic/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/distros/stretch/sd-agent-forwarder.service
+++ b/debian/distros/stretch/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/stretch/sd-agent-jmx.service
+++ b/debian/distros/stretch/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/stretch/sd-agent-sdstatsd.service
+++ b/debian/distros/stretch/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/stretch/sd-agent.service
+++ b/debian/distros/stretch/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/distros/xenial/sd-agent-forwarder.service
+++ b/debian/distros/xenial/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/xenial/sd-agent-jmx.service
+++ b/debian/distros/xenial/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/xenial/sd-agent-sdstatsd.service
+++ b/debian/distros/xenial/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/xenial/sd-agent.service
+++ b/debian/distros/xenial/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/sd-agent-forwarder.service
+++ b/debian/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/sd-agent-jmx.service
+++ b/debian/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/sd-agent-sdstatsd.service
+++ b/debian/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/sd-agent.service
+++ b/debian/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates the service files that are shipped with the agent on systemd enabled servers to prevent the service from automatically logging to syslog, despite disabling syslogging in the agent config. 

Raised in #169 . 

Packages have been tested and logs are not pushed to syslog when the agent is configured not to. 

@NassimHC please can you review/merge? 