### PR TITLE
Uninstall sd-agent-forwarder on sd-agent uninstall

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server


### PR DESCRIPTION
This PR updates the packaging metadata to ensure that sd-agent-forwarder is uninstalled when sd-agent is uninstalled. 

Packages have been tested. 

@NassimHC please can you review/merge? 