### PR TITLE
V2.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - AGENT_VERSION=2.2.3
+    - AGENT_VERSION=2.2.4
     - CACHE_DIR=$HOME/.cache
     - CACHE_FILE_el6=$CACHE_DIR/el6.tar.gz
     - CACHE_FILE_el6_i386=$CACHE_DIR/el6_i386.tar.gz

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "2.2.3"
+AGENT_VERSION = "2.2.4"
 JMX_VERSION = "0.15.0"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sd-agent (2.2.4-1trusty0) trusty; urgency=medium
+
+  * Minor packaging update for systemd enabled OS
+  * Fixed an issue which prevented disabling logging to syslog on systemd enabled OS
+
+ -- Server Density <hello@serverdensity.com>  Thu, 31 Jan 2019 10:30:00 +0100
+
 sd-agent (2.2.3-1trusty0) trusty; urgency=medium
 
   * Security Update: Updates python pyyaml library to address CVE-2017-18342.

--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/bionic/sd-agent-forwarder.service
+++ b/debian/distros/bionic/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/bionic/sd-agent-jmx.service
+++ b/debian/distros/bionic/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/bionic/sd-agent-sdstatsd.service
+++ b/debian/distros/bionic/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/bionic/sd-agent.service
+++ b/debian/distros/bionic/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/stretch/sd-agent-forwarder.service
+++ b/debian/distros/stretch/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/stretch/sd-agent-jmx.service
+++ b/debian/distros/stretch/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/stretch/sd-agent-sdstatsd.service
+++ b/debian/distros/stretch/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/stretch/sd-agent.service
+++ b/debian/distros/stretch/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -29,7 +29,7 @@ Architecture: all
 Breaks: sd-agent (<<2.2.0)
 Replaces: sd-agent (<<2.2.0)
 Pre-Depends: dpkg (>= 1.15.12), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls
+Depends: ${python:Depends}, ${misc:Depends}, libcurl3-gnutls, sd-agent (>=2.2.0)
 Description: The Server Density monitoring agent
  The Server Density monitoring agent is a lightweight process that monitors
  system processes and services, and sends information back to your Server

--- a/debian/distros/xenial/sd-agent-forwarder.service
+++ b/debian/distros/xenial/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/xenial/sd-agent-jmx.service
+++ b/debian/distros/xenial/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/distros/xenial/sd-agent-sdstatsd.service
+++ b/debian/distros/xenial/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/distros/xenial/sd-agent.service
+++ b/debian/distros/xenial/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/sd-agent-forwarder.service
+++ b/debian/sd-agent-forwarder.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/sd-agent-jmx.service
+++ b/debian/sd-agent-jmx.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent-sdstatsd.service

--- a/debian/sd-agent-sdstatsd.service
+++ b/debian/sd-agent-sdstatsd.service
@@ -10,6 +10,8 @@ User=sd-agent
 Restart=always
 RestartSec=3
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=sd-agent.service

--- a/debian/sd-agent.service
+++ b/debian/sd-agent.service
@@ -11,6 +11,8 @@ PIDFile=/run/sd-agent/sd-agent.pid
 Restart=always
 RestartSec=5
 Environment="PYTHONPATH=/usr/share/python/sd-agent,LANG=POSIX"
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/darwin/darwin_version.sh
+++ b/packaging/darwin/darwin_version.sh
@@ -1,2 +1,2 @@
 # Source this file to import version info
-AGENT_VERSION=2.2.3
+AGENT_VERSION=2.2.4

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Thu Jan 31 2019 Server Density <hello@serverdensity.com> 2.2.4-1
+- Minor packaging update for systemd enabled OS
+- Fixed an issue which prevented disabling logging to syslog on systemd enabled OS
 * Thu Jan 10 2019 Server Density <hello@serverdensity.com> 2.2.3-1
 - Security Update: Updates python pyyaml library to address CVE-2017-18342.
 - Enables postback payload compression

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.2.3
+Version: 2.2.4


### PR DESCRIPTION
* Redirect systemd logs to null so that syslogging can be defined in the agent config. 
* Uninstall sd-agent-forwarder on sd-agent uninstall
* Bumps version to v2.2.4

@NassimHC please review/merge on Monday. 

Packages have been tested.