### PR TITLE
Fix jessie builds

### DIFF
--- a/.travis/dockerfiles/jessie/Dockerfile
+++ b/.travis/dockerfiles/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist jessie $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386; do pbuilder-dist jessie $arch create --othermirror "deb http://deb.debian.org/debian/ jessie main contrib non-free|deb-src http://deb.debian.org/debian/ jessie main contrib non-free|deb http://security.debian.org/ jessie/updates main contrib non-free|deb-src http://security.debian.org/ jessie/updates main contrib non-free"; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh

--- a/.travis/dockerfiles/jessie/entrypoint.sh
+++ b/.travis/dockerfiles/jessie/entrypoint.sh
@@ -15,6 +15,7 @@ for arch in amd64 i386; do
     if [ ! -d /packages/"$distro"/"$RELEASE"/"$arch" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"/"$arch"
     fi
+    pbuilder-dist $RELEASE $arch update
     pbuilder-dist $RELEASE $arch build \
     --buildresult /packages/"$distro"/"$RELEASE"/"$arch" *"$RELEASE"*.dsc
 done;

--- a/.travis/dockerfiles/stretch/entrypoint.sh
+++ b/.travis/dockerfiles/stretch/entrypoint.sh
@@ -16,6 +16,7 @@ for arch in amd64 i386; do
     if [ ! -d /packages/"$distro"/"$RELEASE"/"$arch" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"/"$arch"
     fi
+    pbuilder-dist $RELEASE $arch update
     pbuilder-dist $RELEASE $arch build \
     --buildresult /packages/"$distro"/"$RELEASE"/"$arch" *"$RELEASE"*.dsc
 done;

--- a/.travis/dockerfiles/trusty/entrypoint.sh
+++ b/.travis/dockerfiles/trusty/entrypoint.sh
@@ -18,6 +18,7 @@ for arch in amd64 i386; do
     if [ ! -d /packages/"$distro"/"$RELEASE"/"$arch" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"/"$arch"
     fi
+    pbuilder-dist $RELEASE $arch update
     pbuilder-dist $RELEASE $arch build \
     --buildresult /packages/"$distro"/"$RELEASE"/"$arch" *"$RELEASE"*.dsc
 done;

--- a/.travis/dockerfiles/xenial/entrypoint.sh
+++ b/.travis/dockerfiles/xenial/entrypoint.sh
@@ -16,6 +16,7 @@ for arch in amd64 i386; do
     if [ ! -d /packages/"$distro"/"$RELEASE"/"$arch" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"/"$arch"
     fi
+    pbuilder-dist $RELEASE $arch update
     pbuilder-dist $RELEASE $arch build \
     --buildresult /packages/"$distro"/"$RELEASE"/"$arch" *"$RELEASE"*.dsc
 done;


### PR DESCRIPTION
Builds have been failing for the past week as `jessie-updates/` has been removed from the Debian mirrors. This prevents the chroot from being created which causes the build to fail.
 
This PR adds `--other-mirrors` config to the the jessie build working around this issue. 

This also adds a chroot update to all of the debian/ubuntu OS builds so that old chroot envs don't break builds.

@NassimHC please can you review and merge if happy? 