### PR TITLE
Fix jessie build

### DIFF
--- a/.travis/dockerfiles/el6_i386/Dockerfile
+++ b/.travis/dockerfiles/el6_i386/Dockerfile
@@ -1,6 +1,7 @@
 FROM serverdensity/centos:6-i386
 RUN yum install -y yum-plugin-ovl && yum clean all
 RUN rpm -Uvh http://www.city-fan.org/ftp/contrib/yum-repo/rhel6/i386/city-fan.org-release-2-1.rhel6.noarch.rpm
+RUN yum update -y
 RUN yum install epel-release -y
 RUN linux32 yum -y  --enablerepo=city-fan.org install yum-utils \
     rpm-build \

--- a/.travis/dockerfiles/jessie/Dockerfile
+++ b/.travis/dockerfiles/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist jessie $arch create --othermirror "deb http://deb.debian.org/debian/ jessie main contrib non-free|deb-src http://deb.debian.org/debian/ jessie main contrib non-free|deb http://security.debian.org/ jessie/updates main contrib non-free|deb-src http://security.debian.org/ jessie/updates main contrib non-free"; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386; do pbuilder-dist jessie $arch create --mirror "http://deb.debian.org/debian/" --othermirror "deb http://deb.debian.org/debian/ jessie main contrib non-free|deb-src http://deb.debian.org/debian/ jessie main contrib non-free|deb http://security.debian.org/ jessie/updates main contrib non-free|deb-src http://security.debian.org/ jessie/updates main contrib non-free"; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh


### PR DESCRIPTION
Jessie builds started failing again, adding the `--mirror` to the pbuilder-dist command resolves this. 

Whilst working on this the el6_i386 builds started failing too. The base image is old and doesn't get any updates. Adding `yum update -y` to the dockerfile resolved the issue.

@NassimHC please can you review and merge if happy? 