### PR TITLE
Build fix el6 i386

### DIFF
--- a/.travis/dockerfiles/el6_i386/Dockerfile
+++ b/.travis/dockerfiles/el6_i386/Dockerfile
@@ -20,7 +20,8 @@ RUN linux32 yum -y  --enablerepo=city-fan.org install yum-utils \
     ca-certificates
 RUN wget https://centos6.iuscommunity.org/ius-release.rpm
 RUN rpm -Uvh ius-release*.rpm
-RUN linux32 yum -y install python27 python27-devel
+RUN sed -i "s/\$basearch/i686/" /etc/yum.repos.d/ius-archive.repo
+RUN linux32 yum -y install python27 python27-devel --enablerepo=ius-archive --disablerepo=ius
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
     ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \
     ( grep -q :1000: /etc/group || groupadd -g 1000 ubuntu_group ) && \

--- a/.travis/dockerfiles/el6_i386/entrypoint.sh
+++ b/.travis/dockerfiles/el6_i386/entrypoint.sh
@@ -19,7 +19,7 @@ cd /root/el
 chown -R `id -u`:`id -g` /root/el
 function build {
     rpmdir=/root/build/result/$1
-    yum-builddep -y SPECS/sd-agent-$1.spec
+    yum-builddep -y SPECS/sd-agent-$1.spec --enablerepo=ius-archive --disablerepo=ius
     linux32 rpmbuild -ba SPECS/sd-agent-$1.spec && \
     (test -d $rpmdir || mkdir -p $rpmdir) && cp -a /root/el/RPMS/* $rpmdir
 }


### PR DESCRIPTION
This PR fixes the el_i386 builds by switching to the archive repo for ius as python27 is no longer available in the main repo.

Builds are completing successfully with this change and as this change only impacts the docker containers for builds this does not need any further testing. 

However, @NassimHC please can you review and merge if happy? 