### PR TITLE
Enable arm builds for Debian & Ubuntu

### DIFF
--- a/.travis/dockerfiles/bionic/Dockerfile
+++ b/.travis/dockerfiles/bionic/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist bionic $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 armhf arm64; do pbuilder-dist bionic $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/bionic/entrypoint.sh
+++ b/.travis/dockerfiles/bionic/entrypoint.sh
@@ -9,7 +9,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
-for arch in amd64 i386; do
+for arch in amd64 i386 armhf arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi

--- a/.travis/dockerfiles/buster/Dockerfile
+++ b/.travis/dockerfiles/buster/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/buster/entrypoint.sh
+++ b/.travis/dockerfiles/buster/entrypoint.sh
@@ -9,7 +9,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
-for arch in amd64 i386; do
+for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi

--- a/.travis/dockerfiles/stretch/Dockerfile
+++ b/.travis/dockerfiles/stretch/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist stretch $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64 armhf; do pbuilder-dist stretch $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/stretch/entrypoint.sh
+++ b/.travis/dockerfiles/stretch/entrypoint.sh
@@ -9,7 +9,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
-for arch in amd64 i386; do
+for arch in amd64 i386 arm64 armhf; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi

--- a/.travis/dockerfiles/trusty/Dockerfile
+++ b/.travis/dockerfiles/trusty/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist trusty $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 armhf arm64; do pbuilder-dist trusty $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh

--- a/.travis/dockerfiles/trusty/entrypoint.sh
+++ b/.travis/dockerfiles/trusty/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 sudo rm -rf /sd-agent/debian/control
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
 cat /sd-agent/debian/control
-for arch in amd64 i386; do
+for arch in amd64 i386 armhf arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi

--- a/.travis/dockerfiles/xenial/Dockerfile
+++ b/.travis/dockerfiles/xenial/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist xenial $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 armhf arm64; do pbuilder-dist xenial $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-classic" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/xenial/entrypoint.sh
+++ b/.travis/dockerfiles/xenial/entrypoint.sh
@@ -9,7 +9,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
-for arch in amd64 i386; do
+for arch in amd64 i386 armhf arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi


### PR DESCRIPTION
Enables builds for arm64 arch type on Debian and Ubuntu OS's. 

Debian Jessie was skipped as it is EoL June 30th 2020. 