### PR TITLE
Fix Travis CI OS X Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
 # Override travis defaults with empty jobs
 before_install:
-- rvm install 2.1.5
+- if [ "${TRAVIS_OS_NAME}" != "osx" ]; then rvm install 2.1.5; fi
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static createrepo reprepro; fi


### PR DESCRIPTION
On the previous PR I didn't anticipate any issues with OS X, however it unintentionally broke the OS X builds with the rvm install command. 

This PR fixes that issue and allows OS X builds to complete successfully. 

@NassimHC please review :) 