### PR TITLE
bump ntplib - 0.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ boto==2.46.1
 docker-py==1.10.6
 # utils/service_discovery/config_stores.py
 kazoo==2.4.0
-ntplib==0.3.3
+ntplib==0.3.4
 # utils/service_discovery/config_stores.py
 python-consul==0.4.7
 # utils/service_discovery/config_stores.py


### PR DESCRIPTION
This PR bumps the ntplib version pin to 0.3.4 as 0.3.3 was removed from pypi. 

A version bump is required as we have updated deps, but this will come in a later PR which brings focal builds.

@NassimHC please review and merge if happy