### PR TITLE
Update ius-release URLs for Travis Builds

### DIFF
--- a/.travis/dockerfiles/el6/Dockerfile
+++ b/.travis/dockerfiles/el6/Dockerfile
@@ -13,7 +13,7 @@ RUN yum -y install \
     tar \
     symlinks \
     epel-release
-RUN wget https://centos6.iuscommunity.org/ius-release.rpm && \
+RUN wget https://repo.ius.io/ius-release-el6.rpm && \
     rpm -Uvh ius-release*.rpm && \
     yum -y install python27 python27-devel
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \

--- a/.travis/dockerfiles/el6_i386/Dockerfile
+++ b/.travis/dockerfiles/el6_i386/Dockerfile
@@ -18,7 +18,7 @@ RUN linux32 yum -y  --enablerepo=city-fan.org install yum-utils \
     symlinks \
     git \
     ca-certificates
-RUN wget https://centos6.iuscommunity.org/ius-release.rpm
+RUN wget https://repo.ius.io/ius-release-el6.rpm
 RUN rpm -Uvh ius-release*.rpm
 RUN sed -i "s|https://repo.ius.io/archive/6/\$basearch/|https://dl.iuscommunity.org/pub/ius/archive/CentOS/6/i386/|" /etc/yum.repos.d/ius-archive.repo
 RUN rpm --import https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY


### PR DESCRIPTION
Updates the ius-release URLs that are used in the build containers as the redirects no longer work. 

Builds are passing with this change.

@NassimHC please review and merge if happy. 