### PR TITLE
Bump setuptools to 44.1.1

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ define create_venv
 	curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
-	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
+	$(BUILD_DIR)/bin/python ez_setup.py --version="44.1.1"
 	curl -LO https://bootstrap.pypa.io/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef

--- a/packaging/el/SPECS/sd-agent-el6.spec
+++ b/packaging/el/SPECS/sd-agent-el6.spec
@@ -34,7 +34,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
-%{__venv}/bin/python ez_setup.py --version="20.9.0"
+%{__venv}/bin/python ez_setup.py --version="44.1.1"
 curl -LO https://bootstrap.pypa.io/get-pip.py
 %{__venv}/bin/python get-pip.py
 

--- a/packaging/el/SPECS/sd-agent-el7.spec
+++ b/packaging/el/SPECS/sd-agent-el7.spec
@@ -34,7 +34,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
-%{__venv}/bin/python ez_setup.py --version="20.9.0"
+%{__venv}/bin/python ez_setup.py --version="44.1.1"
 curl -LO https://bootstrap.pypa.io/get-pip.py
 %{__venv}/bin/python get-pip.py
 

--- a/packaging/el/SPECS/sd-agent-el8.spec
+++ b/packaging/el/SPECS/sd-agent-el8.spec
@@ -34,7 +34,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
-%{__venv}/bin/python ez_setup.py --version="20.9.0"
+%{__venv}/bin/python ez_setup.py --version="44.1.1"
 curl -LO https://bootstrap.pypa.io/get-pip.py
 %{__venv}/bin/python get-pip.py
 


### PR DESCRIPTION
This PR bumps setuptools to v44.1.1 so that the builds match between sd-agent and sd-agent-core plugins. 

Setuptools is not shipped with the agent, so this does not need a version bump and release as this impacts builds only. 

@NassimHC please review.