### PR TITLE
Build Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     - DD_CASHER_DIR=/tmp/casher
     - AGENT_VERSION=2.2.8
     - CACHE_DIR=$HOME/.cache
-    - CACHE_FILE_el6=$CACHE_DIR/el6.tar.gz
-    - CACHE_FILE_el6_i386=$CACHE_DIR/el6_i386.tar.gz
     - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
     - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
     - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
@@ -94,14 +92,6 @@ jobs:
       script: travis_retry ./.travis/build_containers.sh
       python: 2.7
       env: RELEASE=trusty
-    - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
-      env: RELEASE=el6
-    - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
-      env: RELEASE=el6_i386
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
       python: 2.7
@@ -197,34 +187,6 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=trusty
-      python: 2.7
-      deploy:
-      - provider: gcs
-        access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
-        secret_access_key:
-            secure: EyTxi3GZOlwGmYT0eld3copYEGLoymOo2ZO7jXkUa4bVmdbSpUHokYAVip6r+zf42tfKhzr1S2GWPDKhF/AozYX9ZOtvzojK92RGmwp6B1n1JIKWgqHE91LaIArp1i+sPk4ACe6dann1N7KKXcjyCNXXjjaw9RHogNHp2muc9vQ=
-        bucket: "sd-agent-packages"
-        acl: public-read
-        local_dir: /serverdensity
-        on:
-          all_branches: true
-    - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
-      env: RELEASE=el6
-      python: 2.7
-      deploy:
-      - provider: gcs
-        access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
-        secret_access_key:
-            secure: EyTxi3GZOlwGmYT0eld3copYEGLoymOo2ZO7jXkUa4bVmdbSpUHokYAVip6r+zf42tfKhzr1S2GWPDKhF/AozYX9ZOtvzojK92RGmwp6B1n1JIKWgqHE91LaIArp1i+sPk4ACe6dann1N7KKXcjyCNXXjjaw9RHogNHp2muc9vQ=
-        bucket: "sd-agent-packages"
-        acl: public-read
-        local_dir: /serverdensity
-        on:
-          all_branches: true
-    - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
-      env: RELEASE=el6_i386
       python: 2.7
       deploy:
       - provider: gcs

--- a/.travis/dockerfiles/bionic/entrypoint.sh
+++ b/.travis/dockerfiles/bionic/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -9,6 +8,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"

--- a/.travis/dockerfiles/buster/entrypoint.sh
+++ b/.travis/dockerfiles/buster/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -9,6 +8,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"

--- a/.travis/dockerfiles/el8/Dockerfile
+++ b/.travis/dockerfiles/el8/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 RUN yum -y install yum-utils
-RUN yum-config-manager --enable PowerTools
+RUN yum-config-manager --enable powertools
 RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2
 
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \

--- a/.travis/dockerfiles/focal/entrypoint.sh
+++ b/.travis/dockerfiles/focal/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -9,6 +8,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 for arch in amd64 ; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"

--- a/.travis/dockerfiles/stretch/entrypoint.sh
+++ b/.travis/dockerfiles/stretch/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -9,6 +8,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"

--- a/.travis/dockerfiles/trusty/entrypoint.sh
+++ b/.travis/dockerfiles/trusty/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -10,6 +9,7 @@ else
 fi
 sudo rm -rf /sd-agent/debian/control
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 cat /sd-agent/debian/control
 for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then

--- a/.travis/dockerfiles/xenial/entrypoint.sh
+++ b/.travis/dockerfiles/xenial/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 sudo sed -i "s|trusty|$RELEASE|" /sd-agent*/debian/changelog
-sudo dpkg-source -b /sd-agent
 ubuntu=(bionic focal xenial trusty)
 if [[ ${ubuntu[*]} =~ "$RELEASE" ]]
 then
@@ -9,6 +8,7 @@ else
     distro="debian"
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
+sudo dpkg-source -b /sd-agent
 for arch in amd64 i386 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/serverdensity/sd-agent.svg?branch=master)](https://travis-ci.org/serverdensity/sd-agent)
+[![Build Status](https://travis-ci.com/serverdensity/sd-agent.svg?branch=master)](https://travis-ci.com/serverdensity/sd-agent)
 
 This is the source code for the Server Density agent (v2). If you're looking to install the agent, we also provide [pre-packaged binaries](https://support.serverdensity.com/hc/en-us/articles/360001083126) for most operating systems.
 

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task 'setup_env' do
   `python venv/virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools venv/`
   `wget -O venv/ez_setup.py https://bootstrap.pypa.io/ez_setup.py`
   `venv/bin/python venv/ez_setup.py --version="20.9.0"`
-  `wget -O venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`
+  `wget -O venv/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py`
   `venv/bin/python venv/get-pip.py`
   `venv/bin/pip install -r requirements.txt`
   `venv/bin/pip install -r requirements-test.txt`

--- a/debian/distros/bionic/rules
+++ b/debian/distros/bionic/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/bionic/rules
+++ b/debian/distros/bionic/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/distros/buster/rules
+++ b/debian/distros/buster/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/buster/rules
+++ b/debian/distros/buster/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/distros/focal/rules
+++ b/debian/distros/focal/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/focal/rules
+++ b/debian/distros/focal/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/distros/stretch/rules
+++ b/debian/distros/stretch/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/stretch/rules
+++ b/debian/distros/stretch/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/distros/trusty/rules
+++ b/debian/distros/trusty/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/trusty/rules
+++ b/debian/distros/trusty/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/distros/xenial/rules
+++ b/debian/distros/xenial/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/distros/xenial/rules
+++ b/debian/distros/xenial/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="20.9.0"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,7 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="44.1.1"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef
 

--- a/debian/rules
+++ b/debian/rules
@@ -40,7 +40,7 @@ define create_venv
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="44.1.1"
 	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
-	$(BUILD_DIR)/bin/python get-pip.py
+	$(BUILD_DIR)/bin/python get-pip.py 'pip<19'
 endef
 
 # The following 3 functions are ported from dh-virtualenv:

--- a/packaging/darwin/build_installer.sh
+++ b/packaging/darwin/build_installer.sh
@@ -29,7 +29,7 @@ tar xzf virtualenv-15.2.0.tar.gz
 /usr/bin/python2.7 virtualenv-15.2.0/virtualenv.py --no-site-packages --no-pip --no-setuptools ${BUILD_DIR}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 ${VENV_PYTHON_CMD} ez_setup.py
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 ${VENV_PYTHON_CMD} get-pip.py
 
 $VENV_PIP_CMD install -r requirements.txt

--- a/packaging/darwin/build_installer.sh
+++ b/packaging/darwin/build_installer.sh
@@ -2,9 +2,9 @@
 set -ev
 
 if [[ "$TRAVIS_TAG" ]]; then
-    PACKAGES_DIR="/${TRAVIS_REPO_SLUG}/${TRAVIS_TAG}/"
+    PACKAGES_DIR="/${TRAVIS_REPO_SLUG}/${TRAVIS_TAG}"
 else
-    PACKAGES_DIR="/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_ID}/"
+    PACKAGES_DIR="/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_ID}"
 fi
 # Build requisites
 PATH=~/Library/Python/2.7/bin:$PATH

--- a/packaging/el/SPECS/sd-agent-el6.spec
+++ b/packaging/el/SPECS/sd-agent-el6.spec
@@ -35,7 +35,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent

--- a/packaging/el/SPECS/sd-agent-el7.spec
+++ b/packaging/el/SPECS/sd-agent-el7.spec
@@ -35,7 +35,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent

--- a/packaging/el/SPECS/sd-agent-el8.spec
+++ b/packaging/el/SPECS/sd-agent-el8.spec
@@ -35,7 +35,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent


### PR DESCRIPTION
This PR: 
* Fixes get-pip URL for 2.7.
* Updates el8 powertools repository name.
* Pins pip to <19.
* Removes el6 from travis config, but has not removed the files.
* Ensures dpkg-source is executed after the control file is updated for the specific ubuntu/debian release.
* Removes an extra / from the PACKAGES_DIR path in MacOS builds ensuring build artifacts are uploaded to GCS.
* Updates travis-ci badge to .com, as the repository has been migrated.

Builds are successful on this branch and the agent has been tested to ensure that this did not inadvertently break any functionality