### PR TITLE
Enable Focal aarch64/arm64 builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
 
 before_script:
+  - if [ "${TRAVIS_DIST}" == "focal" ]; then sudo add-apt-repository ppa:canonical-server/server-backports -y; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static createrepo reprepro; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
 script: travis_retry ./.travis/build_installer.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 os: linux
-language: python
-python:
-  - 2.7
 
 cache:
   directories:
@@ -33,10 +30,6 @@ env:
     - CACHE_FILE_stretch=$CACHE_DIR/stretch.tar.gz
     - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
 
-# Override travis defaults with empty jobs
-before_install:
-- if [ "${TRAVIS_OS_NAME}" != "osx" ]; then rvm install 2.1.5; fi
-
 before_script:
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static createrepo reprepro; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
@@ -52,54 +45,57 @@ notifications:
 jobs:
   include:
     - stage: Tests
+      language: python
       python: 2.7
       services: docker
       env: TRAVIS_FLAVOR=default
     - stage: Tests
+      language: python
       python: 2.7
       services: docker
       env: TRAVIS_FLAVOR=checks_mock
     - stage: Tests
+      language: python
       python: 2.7
       services: docker
       env: TRAVIS_FLAVOR=core_integration
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=buster
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=bionic
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=focal
       dist: focal
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=jessie
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=xenial
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=stretch
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=el7
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
-      python: 2.7
+      rvm: 2.5
       env: RELEASE=el8
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=bionic
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -113,7 +109,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=buster
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -128,7 +124,7 @@ jobs:
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=focal
       dist: focal
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -142,7 +138,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=jessie
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -156,7 +152,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=xenial
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -170,7 +166,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=stretch
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -184,7 +180,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=el7
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
@@ -198,7 +194,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=el8
-      python: 2.7
+      rvm: 2.5
       deploy:
       - provider: gcs
         access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 before_script:
   - if [ "${TRAVIS_DIST}" == "focal" ]; then sudo add-apt-repository ppa:canonical-server/server-backports -y; fi
-  - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static createrepo reprepro; fi
+  - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
 script: travis_retry ./.travis/build_installer.sh
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ jobs:
       script: travis_retry ./.travis/build_containers.sh
       python: 2.7
       env: RELEASE=focal
+      dist: focal
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
       python: 2.7
@@ -126,6 +127,7 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=focal
+      dist: focal
       python: 2.7
       deploy:
       - provider: gcs

--- a/.travis/dockerfiles/focal/Dockerfile
+++ b/.travis/dockerfiles/focal/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64; do pbuilder-dist focal $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 arm64; do pbuilder-dist focal $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
 USENETWORK=yes \n\

--- a/.travis/dockerfiles/focal/entrypoint.sh
+++ b/.travis/dockerfiles/focal/entrypoint.sh
@@ -9,7 +9,7 @@ else
 fi
 sudo cp -a /sd-agent/debian/distros/"$RELEASE"/. /sd-agent/debian
 sudo dpkg-source -b /sd-agent
-for arch in amd64 ; do
+for arch in amd64 arm64; do
     if [ ! -d /packages/"$distro"/"$RELEASE" ]; then
         sudo mkdir -p /packages/"$distro"/"$RELEASE"
     fi


### PR DESCRIPTION
This PR updates the build scripts to enable aarch64/arm64 builds for Ubuntu Focal per customer requests. 

A couple of things to note: 
* The Focal container build and package build stages now run on a Focal host 
* The error `semop(1): encountered an error: Function not implemented` was seen when running the builds and prevented them from completing. To workaround this the `ppa:canonical-server/server-backports`  is added to Focal hosts which allows qemu-user-static backported from Groovy to be installed which resolves this error. [0]
* We were previously using ruby 2.1.5, however Focal does not have the correct dependencies available for this, so I bumped the Ruby version to 2.5 for everything instead of working around the dependency issue with 2.1.5 and Focal.
  * This bump was completed via travis.yaml. The build containers and build packages stages are now Ruby, and the tests stages are python 2.7 
  * Ruby is not really made use of in the builds for sd-agent, however it is a requirement for sd-agent-core-plugins. I opted for this change in sd-agent too in order to maintain as much parity as possible between the builds. 
* Createrepo and reprepro were removed as they are not used in the build and createrepo is not available on Focal+ causing the builds to fail. 

[0] https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1895456