### PR TITLE
Bump Jmxfetch Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - AGENT_VERSION=2.2.8
+    - AGENT_VERSION=2.2.9
     - CACHE_DIR=$HOME/.cache
     - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
     - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz

--- a/.travis/dockerfiles/bullseye/Dockerfile
+++ b/.travis/dockerfiles/bullseye/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support wget
+RUN wget https://ftp.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1_all.deb
+RUN dpkg -i debian-archive-keyring_2021.1.1_all.deb
 RUN echo 'for arch in amd64 i386; do pbuilder-dist bullseye $arch create --mirror "http://deb.debian.org/debian/" --othermirror "deb http://security.debian.org/debian-security bullseye-security main|deb-src http://security.debian.org/ bullseye-security main|deb http://deb.debian.org/debian bullseye-updates main|deb-src http://deb.debian.org/debian bullseye-updates main"; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\

--- a/.travis/dockerfiles/buster/Dockerfile
+++ b/.travis/dockerfiles/buster/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support wget
+RUN wget https://ftp.debian.org/debian/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1_all.deb
+RUN dpkg -i debian-archive-keyring_2021.1.1_all.deb
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "2.2.8"
-JMX_VERSION = "0.20.1"
+JMX_VERSION = "0.44.4"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'
 MAC_CONFIG_PATH = '/usr/local/etc/sd-agent/'

--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "2.2.8"
+AGENT_VERSION = "2.2.9"
 JMX_VERSION = "0.44.4"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent (2.2.9-1trusty0) trusty; urgency=medium
+
+  * Updates JMXFetch to 0.44.4
+
+ -- Server Density <hello@serverdensity.com>  Tue, 14 Dec 2021 10:30:00 +0100
+
 sd-agent (2.2.8-1trusty0) trusty; urgency=medium
 
   * Updates ntplib python dependency

--- a/debian/distros/bionic/rules
+++ b/debian/distros/bionic/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/bullseye/rules
+++ b/debian/distros/bullseye/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/buster/rules
+++ b/debian/distros/buster/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/focal/rules
+++ b/debian/distros/focal/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/stretch/rules
+++ b/debian/distros/stretch/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/trusty/rules
+++ b/debian/distros/trusty/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/xenial/rules
+++ b/debian/distros/xenial/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.20.1
+JMX_VERSION=0.44.4
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/packaging/darwin/darwin_version.sh
+++ b/packaging/darwin/darwin_version.sh
@@ -1,2 +1,2 @@
 # Source this file to import version info
-AGENT_VERSION=2.2.8
+AGENT_VERSION=2.2.9

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+ * Tue Dec 14 2021 Server Density <hello@serverdensity.com> 2.2.9-1
+- Updates JMXFetch to 0.44.4
 * Tue May 5 2020 Server Density <hello@serverdensity.com> 2.2.8-1
 - Updates ntplib python dependency
 * Tue Mar 17 2020 Server Density <hello@serverdensity.com> 2.2.7-1

--- a/packaging/el/inc/download_jmx_fetch
+++ b/packaging/el/inc/download_jmx_fetch
@@ -1,5 +1,5 @@
 %define         jmxfetch_url https://dd-jmxfetch.s3.amazonaws.com
-%define         jmx_version 0.20.1
+%define         jmx_version 0.44.4
 %define         jmx_artifact jmxfetch-%{jmx_version}-jar-with-dependencies.jar
 
 curl -LO %{jmxfetch_url}/%{jmx_artifact}

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.2.8
+Version: 2.2.9


### PR DESCRIPTION
* Bumps jmxfetch to 0.44.4 to mitigate CVE-2021-44228
* Bumps sd-agent version number to 2.2.9
* Minor build fixes for bullseye and buster. Builds are completed on 18.04 containers but this does not have the latest debian-archive-keyring in the repository preventing debootstrap from installing required packages. Updated the Dockerfiles to download and install the latest debian-archive-keyring as I hit kernel issues when bumping the ubuntu images to latest than 18.04. 

@pessoa please can you review? 