### PR TITLE
Bump JMXFetch Version - 0.44.5

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "2.2.9"
-JMX_VERSION = "0.44.4"
+JMX_VERSION = "0.44.5"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'
 MAC_CONFIG_PATH = '/usr/local/etc/sd-agent/'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 sd-agent (2.2.9-1trusty0) trusty; urgency=medium
 
-  * Updates JMXFetch to 0.44.4
+  * Updates JMXFetch to 0.44.5 to mitigate CVE-2021-45046 and CVE-2021-44228
 
- -- Server Density <hello@serverdensity.com>  Tue, 14 Dec 2021 10:30:00 +0100
+ -- Server Density <hello@serverdensity.com>  Wed, 15 Dec 2021 10:30:00 +0100
 
 sd-agent (2.2.8-1trusty0) trusty; urgency=medium
 

--- a/debian/distros/bionic/rules
+++ b/debian/distros/bionic/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/bullseye/rules
+++ b/debian/distros/bullseye/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/buster/rules
+++ b/debian/distros/buster/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/focal/rules
+++ b/debian/distros/focal/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/stretch/rules
+++ b/debian/distros/stretch/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/trusty/rules
+++ b/debian/distros/trusty/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/xenial/rules
+++ b/debian/distros/xenial/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.4
+JMX_VERSION=0.44.5
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,6 +1,6 @@
 %changelog
- * Tue Dec 14 2021 Server Density <hello@serverdensity.com> 2.2.9-1
-- Updates JMXFetch to 0.44.4
+ * Wed Dec 15 2021 Server Density <hello@serverdensity.com> 2.2.9-1
+- Updates JMXFetch to 0.44.5 to mitigate CVE-2021-45046 and CVE-2021-44228
 * Tue May 5 2020 Server Density <hello@serverdensity.com> 2.2.8-1
 - Updates ntplib python dependency
 * Tue Mar 17 2020 Server Density <hello@serverdensity.com> 2.2.7-1

--- a/packaging/el/inc/download_jmx_fetch
+++ b/packaging/el/inc/download_jmx_fetch
@@ -1,5 +1,5 @@
 %define         jmxfetch_url https://dd-jmxfetch.s3.amazonaws.com
-%define         jmx_version 0.44.4
+%define         jmx_version 0.44.5
 %define         jmx_artifact jmxfetch-%{jmx_version}-jar-with-dependencies.jar
 
 curl -LO %{jmxfetch_url}/%{jmx_artifact}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+lazy-object-proxy==1.6.0
 nose==1.3.4
 flake8==3.5.0
 mock==2.0.0


### PR DESCRIPTION
* Bumps JMXFetch version to 0.44.5 to mitigate CVE-2021-45046 and CVE-2021-44228
* Pins lazy-object-proxy==1.6.0 to ensure test requirements can be installed. 

Agent version did not get bump as we have not released it yet.

@pessoa please can I have a review? 