### PR TITLE
Add El ARM Packaging 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - AGENT_VERSION=2.2.9
     - CACHE_DIR=$HOME/.cache
     - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
+    - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz
     - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
     - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
     - CACHE_FILE_buster=$CACHE_DIR/buster.tar.gz
@@ -94,6 +95,11 @@ jobs:
       script: travis_retry ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el7
+    - stage: build containers
+      script: travis_retry ./.travis/build_containers.sh
+      rvm: 2.5
+      env: RELEASE=el7_arm
+      dist: focal
     - stage: build containers
       script: travis_retry ./.travis/build_containers.sh
       rvm: 2.5
@@ -200,6 +206,21 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=el7
+      rvm: 2.5
+      deploy:
+      - provider: gcs
+        access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
+        secret_access_key:
+            secure: EyTxi3GZOlwGmYT0eld3copYEGLoymOo2ZO7jXkUa4bVmdbSpUHokYAVip6r+zf42tfKhzr1S2GWPDKhF/AozYX9ZOtvzojK92RGmwp6B1n1JIKWgqHE91LaIArp1i+sPk4ACe6dann1N7KKXcjyCNXXjjaw9RHogNHp2muc9vQ=
+        bucket: "sd-agent-packages"
+        acl: public-read
+        local_dir: /serverdensity
+        on:
+          all_branches: true
+    - stage: build packages
+      script: travis_retry ./.travis/build_packages.sh
+      env: RELEASE=el7_arm
+      dist: focal
       rvm: 2.5
       deploy:
       - provider: gcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
     - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz
     - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
+    - CACHE_FILE_el8_arm=$CACHE_DIR/el8_arm.tar.gz
     - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
     - CACHE_FILE_buster=$CACHE_DIR/buster.tar.gz
     - CACHE_FILE_bullseye=$CACHE_DIR/bullseye.tar.gz
@@ -104,6 +105,11 @@ jobs:
       script: travis_retry ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el8
+    - stage: build containers
+      script: travis_retry ./.travis/build_containers.sh
+      rvm: 2.5
+      env: RELEASE=el8_arm
+      dist: focal
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=bionic
@@ -235,6 +241,21 @@ jobs:
     - stage: build packages
       script: travis_retry ./.travis/build_packages.sh
       env: RELEASE=el8
+      rvm: 2.5
+      deploy:
+      - provider: gcs
+        access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
+        secret_access_key:
+            secure: EyTxi3GZOlwGmYT0eld3copYEGLoymOo2ZO7jXkUa4bVmdbSpUHokYAVip6r+zf42tfKhzr1S2GWPDKhF/AozYX9ZOtvzojK92RGmwp6B1n1JIKWgqHE91LaIArp1i+sPk4ACe6dann1N7KKXcjyCNXXjjaw9RHogNHp2muc9vQ=
+        bucket: "sd-agent-packages"
+        acl: public-read
+        local_dir: /serverdensity
+        on:
+          all_branches: true
+    - stage: build packages
+      script: travis_retry ./.travis/build_packages.sh
+      env: RELEASE=el8_arm
+      dist: focal
       rvm: 2.5
       deploy:
       - provider: gcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - if [ "${TRAVIS_DIST}" == "focal" ]; then sudo add-apt-repository ppa:canonical-server/server-backports -y; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static; fi
   - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
-script: travis_retry ./.travis/build_installer.sh
+script: travis_retry travis_wait 50 ./.travis/build_installer.sh
 after_failure:
   - echo "Logs from installation process come here / DEBUG LOGS"
   - cat /tmp/ci.log
@@ -64,54 +64,54 @@ jobs:
       services: docker
       env: TRAVIS_FLAVOR=core_integration
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=buster
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=bullseye
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=bionic
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=focal
       dist: focal
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=jessie
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=xenial
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=stretch
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el7
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el7_arm
       dist: focal
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el8
     - stage: build containers
-      script: travis_retry ./.travis/build_containers.sh
+      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
       env: RELEASE=el8_arm
       dist: focal
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=bionic
       rvm: 2.5
       deploy:
@@ -125,7 +125,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=buster
       rvm: 2.5
       deploy:
@@ -139,7 +139,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=bullseye
       rvm: 2.5
       deploy:
@@ -153,7 +153,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=focal
       dist: focal
       rvm: 2.5
@@ -168,7 +168,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=jessie
       rvm: 2.5
       deploy:
@@ -182,7 +182,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=xenial
       rvm: 2.5
       deploy:
@@ -196,7 +196,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=stretch
       rvm: 2.5
       deploy:
@@ -210,7 +210,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=el7
       rvm: 2.5
       deploy:
@@ -224,7 +224,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=el7_arm
       dist: focal
       rvm: 2.5
@@ -239,7 +239,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=el8
       rvm: 2.5
       deploy:
@@ -253,7 +253,7 @@ jobs:
         on:
           all_branches: true
     - stage: build packages
-      script: travis_retry ./.travis/build_packages.sh
+      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=el8_arm
       dist: focal
       rvm: 2.5

--- a/.travis/dockerfiles/el7_arm/Dockerfile
+++ b/.travis/dockerfiles/el7_arm/Dockerfile
@@ -1,0 +1,9 @@
+FROM arm64v8/centos:7
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python-devel wget curl libyaml-devel curl-devel postgresql-devel tar
+
+RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
+    ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \
+    ( grep -q :1000: /etc/group || groupadd -g 1000 ubuntu_group ) && \
+    ( grep -q :1000: /etc/passwd || useradd  -u 1000 -g 1000 ubuntu_user )
+COPY ./entrypoint.sh /
+CMD ["/entrypoint.sh"]

--- a/.travis/dockerfiles/el7_arm/entrypoint.sh
+++ b/.travis/dockerfiles/el7_arm/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -xe
+
+cat > $HOME/.rpmmacros << EOF_MACROS
+%_topdir /root/el
+%_tmppath %{_topdir}/tmp
+EOF_MACROS
+
+mkdir /root/el
+cd /root/el
+for dir in SOURCES BUILD RPMS SRPMS; do
+    [ -d $dir ] || mkdir $dir
+done
+sd_agent_version=$(awk -F'"' '/^AGENT_VERSION/ {print $2}' /sd-agent/config.py)
+tar -czf /root/el/SOURCES/sd-agent-${sd_agent_version}.tar.gz /sd-agent
+cp -a /sd-agent/packaging/el/{SPECS,inc,description} /root/el
+cd /root/el
+chown -R `id -u`:`id -g` /root/el
+function build {
+    rpmdir=/root/build/result/$1
+    yum-builddep -y SPECS/sd-agent-$1.spec
+    rpmbuild -ba SPECS/sd-agent-$1.spec && \
+    (test -d $rpmdir || mkdir -p $rpmdir) && cp -a /root/el/RPMS/* $rpmdir
+}
+build "el7"
+if [ ! -d /packages/el ]; then
+    mkdir /packages/el
+fi
+
+if [ ! -d /packages/el/7 ]; then
+    mkdir /packages/el/7
+fi
+
+if [ ! -d /packages/src ]; then
+    mkdir /packages/src
+fi
+cp -r /root/el/RPMS/* /packages/el/7
+cp -r /root/el/SRPMS/* /packages/src

--- a/.travis/dockerfiles/el8/Dockerfile
+++ b/.travis/dockerfiles/el8/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum -y install yum-utils
 RUN yum-config-manager --enable powertools
 RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2

--- a/.travis/dockerfiles/el8_arm/Dockerfile
+++ b/.travis/dockerfiles/el8_arm/Dockerfile
@@ -1,0 +1,15 @@
+FROM arm64v8/centos:8
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+RUN yum -y install yum-utils
+RUN yum-config-manager --enable powertools
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2
+
+RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
+    ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \
+    ( grep -q :1000: /etc/group || groupadd -g 1000 ubuntu_group ) && \
+    ( grep -q :1000: /etc/passwd || useradd  -u 1000 -g 1000 ubuntu_user )
+COPY ./entrypoint.sh /
+CMD ["/entrypoint.sh"]

--- a/.travis/dockerfiles/el8_arm/entrypoint.sh
+++ b/.travis/dockerfiles/el8_arm/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -xe
+
+cat > $HOME/.rpmmacros << EOF_MACROS
+%_topdir /root/el
+%_tmppath %{_topdir}/tmp
+EOF_MACROS
+
+mkdir /root/el
+cd /root/el
+for dir in SOURCES BUILD RPMS SRPMS; do
+    [ -d $dir ] || mkdir $dir
+done
+sd_agent_version=$(awk -F'"' '/^AGENT_VERSION/ {print $2}' /sd-agent/config.py)
+tar -czf /root/el/SOURCES/sd-agent-${sd_agent_version}.tar.gz /sd-agent
+cp -a /sd-agent/packaging/el/{SPECS,inc,description} /root/el
+cd /root/el
+chown -R `id -u`:`id -g` /root/el
+function build {
+    rpmdir=/root/build/result/$1
+    yum-builddep -y SPECS/sd-agent-$1.spec
+    rpmbuild -ba SPECS/sd-agent-$1.spec --define="_build_id_links none" && \
+    (test -d $rpmdir || mkdir -p $rpmdir) && cp -a /root/el/RPMS/* $rpmdir
+}
+build "el8"
+if [ ! -d /packages/el ]; then
+    mkdir /packages/el
+fi
+
+if [ ! -d /packages/el/8 ]; then
+    mkdir /packages/el/8
+fi
+
+if [ ! -d /packages/src ]; then
+    mkdir /packages/src
+fi
+cp -r /root/el/RPMS/* /packages/el/8
+cp -r /root/el/SRPMS/* /packages/src

--- a/packaging/el/SPECS/sd-agent-el7.spec
+++ b/packaging/el/SPECS/sd-agent-el7.spec
@@ -13,7 +13,6 @@
 
 Summary: Server Density Monitoring Agent
 Name: sd-agent
-BuildArch: x86_64 i386
 %include %{_topdir}/inc/version
 %include %{_topdir}/inc/release
 Requires: python >= 2.7, sysstat, libyaml, %{name}-forwarder, %{name}-sd-cpu-stats, %{name}-network, %{name}-disk

--- a/packaging/el/SPECS/sd-agent-el8.spec
+++ b/packaging/el/SPECS/sd-agent-el8.spec
@@ -13,7 +13,6 @@
 
 Summary: Server Density Monitoring Agent
 Name: sd-agent
-BuildArch: x86_64 i386
 %include %{_topdir}/inc/version
 %include %{_topdir}/inc/release
 Requires: python2 >= 2.7, sysstat, libyaml, %{name}-forwarder, %{name}-sd-cpu-stats, %{name}-network, %{name}-disk


### PR DESCRIPTION
This PR: 

* Fixes an error in the el8 build containers.
* Adds packaging for aarch64 for el7/8
* Removes the BuildArch from the el SPEC files as the build arch is implied from the build container's arch. 
* Adds travis_wait to all script commands as the el containers do not output anything for over 10mins (causing the build to be deemed failed) despite still running.
