### PR TITLE
Bump jmxfetch to 0.44.6

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "2.2.9"
-JMX_VERSION = "0.44.5"
+JMX_VERSION = "0.44.6"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'
 MAC_CONFIG_PATH = '/usr/local/etc/sd-agent/'

--- a/debian/distros/bionic/rules
+++ b/debian/distros/bionic/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/bullseye/rules
+++ b/debian/distros/bullseye/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/buster/rules
+++ b/debian/distros/buster/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/focal/rules
+++ b/debian/distros/focal/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/stretch/rules
+++ b/debian/distros/stretch/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/trusty/rules
+++ b/debian/distros/trusty/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/distros/xenial/rules
+++ b/debian/distros/xenial/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 BUILD_DIR=debian/build
 DEST_VENV=/usr/share/python/sd-agent
 JMXFETCH_URL=https://dd-jmxfetch.s3.amazonaws.com
-JMX_VERSION=0.44.5
+JMX_VERSION=0.44.6
 JMX_ARTIFACT=jmxfetch-${JMX_VERSION}-jar-with-dependencies.jar
 
 %:

--- a/packaging/el/inc/download_jmx_fetch
+++ b/packaging/el/inc/download_jmx_fetch
@@ -1,5 +1,5 @@
 %define         jmxfetch_url https://dd-jmxfetch.s3.amazonaws.com
-%define         jmx_version 0.44.5
+%define         jmx_version 0.44.6
 %define         jmx_artifact jmxfetch-%{jmx_version}-jar-with-dependencies.jar
 
 curl -LO %{jmxfetch_url}/%{jmx_artifact}


### PR DESCRIPTION
This PR:

* Bumps JMXFetch to 0.44.6 which removes log4j entirely.

The builds will fail until #201 is merged as #201 contains a fix for the el8 build container.