### PR TITLE
Pin urllib3==1.24.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,8 @@ pyyaml>=4.2b1
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.0
+# needed to ensure http-check works, python-etcd pulls in urllib3-1.26.8 which is incompatible with requests
+urllib3==1.24.3
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.3


### PR DESCRIPTION
This PR pins urllib3==1.24.3. 

This is required as the http-check makes use of requests and urllib3, but the dependency for requests is specified in the core agent. 

python-etcd was pulling in urllib3-1.26.8 which is not compatible with the current requests version.  urllib3==1.24.3 satisfies the requirements of both requests and python-etcd and ensures that the http-check will function without user intervention. 

Also a minor fix in the travis yml to ensure csvlint runs. 

@pessoa to review