### PR TITLE
Remove Jessie Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
     - CACHE_FILE_bullseye=$CACHE_DIR/bullseye.tar.gz
     - CACHE_FILE_focal=$CACHE_DIR/focal.tar.gz
     - CACHE_FILE_jammy=$CACHE_DIR/jammy.tar.gz
-    - CACHE_FILE_jessie=$CACHE_DIR/jessie.tar.gz
     - CACHE_FILE_stretch=$CACHE_DIR/stretch.tar.gz
     - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
 
@@ -86,10 +85,6 @@ jobs:
       rvm: 2.5
       env: RELEASE=jammy
       dist: focal
-    - stage: build containers
-      script: travis_retry travis_wait 50 ./.travis/build_containers.sh
-      rvm: 2.5
-      env: RELEASE=jessie
     - stage: build containers
       script: travis_retry travis_wait 50 ./.travis/build_containers.sh
       rvm: 2.5
@@ -177,20 +172,6 @@ jobs:
       script: travis_retry travis_wait 50 ./.travis/build_packages.sh
       env: RELEASE=jammy
       dist: focal
-      rvm: 2.5
-      deploy:
-      - provider: gcs
-        access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
-        secret_access_key:
-            secure: EyTxi3GZOlwGmYT0eld3copYEGLoymOo2ZO7jXkUa4bVmdbSpUHokYAVip6r+zf42tfKhzr1S2GWPDKhF/AozYX9ZOtvzojK92RGmwp6B1n1JIKWgqHE91LaIArp1i+sPk4ACe6dann1N7KKXcjyCNXXjjaw9RHogNHp2muc9vQ=
-        bucket: "sd-agent-packages"
-        acl: public-read
-        local_dir: /serverdensity
-        on:
-          all_branches: true
-    - stage: build packages
-      script: travis_retry travis_wait 50 ./.travis/build_packages.sh
-      env: RELEASE=jessie
       rvm: 2.5
       deploy:
       - provider: gcs


### PR DESCRIPTION
This PR removes Jessie builds from the Travis config.

Jessie is EoL for years and the builds are now failing. We have old builds and will preserve an old version of the agent for Jessie in the repos, per other EoL OS.

@pessoa to review.