### PR TITLE
Bump agent version to 2.2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - AGENT_VERSION=2.2.10
+    - AGENT_VERSION=2.2.11
     - CACHE_DIR=$HOME/.cache
     - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
     - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz

--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "2.2.10"
+AGENT_VERSION = "2.2.11"
 JMX_VERSION = "0.44.6"
 SD_CONF = "config.cfg"
 UNIX_CONFIG_PATH = '/etc/sd-agent'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent (2.2.11-1trusty0) trusty; urgency=medium
+
+  * Fixes urllib3 dependency.
+
+ -- Server Density <hello@serverdensity.com>  Thu, 2 Mar 2023 10:30:00 +0100
+
 sd-agent (2.2.10-1trusty0) trusty; urgency=medium
 
   * Updates JMXFetch to 0.44.6, removing jog4j

--- a/packaging/darwin/darwin_version.sh
+++ b/packaging/darwin/darwin_version.sh
@@ -1,2 +1,2 @@
 # Source this file to import version info
-AGENT_VERSION=2.2.10
+AGENT_VERSION=2.2.11

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,7 +1,9 @@
 %changelog
- * Tue Feb 22 2022 Server Density <hello@serverdensity.com> 2.2.10-1
+* Thu Mar 2 2023 Server Density <hello@serverdensity.com> 2.2.11-1
+- Fixes urllib3 dependency.
+* Tue Feb 22 2022 Server Density <hello@serverdensity.com> 2.2.10-1
 - Updates JMXFetch to 0.44.6, removing log4j
- * Wed Dec 15 2021 Server Density <hello@serverdensity.com> 2.2.9-1
+* Wed Dec 15 2021 Server Density <hello@serverdensity.com> 2.2.9-1
 - Updates JMXFetch to 0.44.5 to mitigate CVE-2021-45046 and CVE-2021-44228
 * Tue May 5 2020 Server Density <hello@serverdensity.com> 2.2.8-1
 - Updates ntplib python dependency

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.2.10
+Version: 2.2.11


### PR DESCRIPTION
This PR bumps the packaging version to 2.6.7, ready for release.

Ideally this should be merged last, after #207 & #208

@pessoa to review